### PR TITLE
Add utterances script to enable comments

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -1,0 +1,6 @@
+{% extends "after-dark/templates/page.html" %}
+{% block extra_footer %}
+<script src="https://utteranc.es/client.js" repo="sinon/sinon.github.io" issue-term="url" label="comments"
+    theme="github-dark" crossorigin="anonymous" async>
+    </script>
+{% endblock %}


### PR DESCRIPTION
## Why?

Oppurtunity for engagement.... before I even publish anything.

## What?

Extend the `extra_footer` of the `after-dark` theme to add the scripts comment comment. 

![image](https://github.com/user-attachments/assets/dd4aa6df-92e8-401c-8f5f-7136336f7d4e)

